### PR TITLE
Fix return statement of bash function

### DIFF
--- a/bin/helpers.sh
+++ b/bin/helpers.sh
@@ -108,5 +108,5 @@ show_header(){
 # function first_letter_lower
 first_letter_lower(){
 	result=$(echo $1 | tr '[:upper:]' '[:lower:]' | cut -b1)
-	return result
+	echo $result
 }


### PR DESCRIPTION
## Purpose
Install of ohmyzsh fails because of invalid bash return statement

## Approach
Fix the `return` keyword with `echo`

#### Open issue
Fixing https://github.com/DavidCardoso/my-env-on-ubuntu/issues/19


